### PR TITLE
Explicitly select which adbusters to support

### DIFF
--- a/adbusters.php
+++ b/adbusters.php
@@ -46,6 +46,7 @@ function wpcom_vip_maybe_load_ad_busters() {
 	$ad_busters = array(
 		'adcentric/ifr_b.html',              // AdCentric
 		'atlas/atlas_rm.htm',                // Atlas
+		'blogads/iframebuster-4.html',       // BlogAds
 		'checkm8/CM8IframeBuster.html',      // CheckM8
 		'doubleclick/DARTIframe.html',       // Google - DoubleClick
 		'doubleclick/fif.html',              // Flite

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,8 @@ Are you troubled by strange iframe ad files in the middle of the night? Do you e
 
 If the answer is yes, don't wait another minute! ADBUSTERS! Download this plugin today and let us take care of your ad file serving needs.
 
+Caveat: while we have reviewed the included templates for obvious security issues (like XSS), we cannot guarantee the reliability of external scripts referenced by most of the adbusters. We highly recommend discussing with your ad network representative to discuss this if you have any concerns.
+
 == Changelog ==
 = 1.0 =
 * First release.
@@ -23,6 +25,7 @@ If the answer is yes, don't wait another minute! ADBUSTERS! Download this plugin
 = What ad network iframes are supported? =
 
 * /atlas/atlas_rm.htm
+* /blogads/iframebuster-4.html
 * /doubleclick/DARTIframe.html
 * /eyeblaster/addineyeV2.html
 * /mediamind/MMbuster.html

--- a/templates/blogads/iframebuster-4.html
+++ b/templates/blogads/iframebuster-4.html
@@ -1,0 +1,7 @@
+<script>
+var skin_js_url = document.location.search.replace('?skin_js=','');
+var skin_js = window.top.document.createElement("script"); 
+skin_js.setAttribute("type", 'text/javascript'); 
+skin_js.setAttribute("src", 'http://skins.blogads.com/' + decodeURIComponent(skin_js_url)); 
+window.top.document.getElementsByTagName('head')[0].appendChild(skin_js);
+</script>

--- a/templates/blogads/index.php
+++ b/templates/blogads/index.php
@@ -1,0 +1,4 @@
+<?php
+/**
+ * Don't modify the files in this folder.
+ */


### PR DESCRIPTION
Introducing a new filter ‘wpcom_vip_maybe_load_ad_busters_whitelist’
that allows selection which adbusters to be served. See issue #2.
