### PR TITLE
Add a new version of addineye iframe buster

### DIFF
--- a/templates/eyeblaster/addineyeV2.html
+++ b/templates/eyeblaster/addineyeV2.html
@@ -2,7 +2,13 @@
 <HEAD>
 </HEAD>
 <BODY style=margin:0;padding:0>
-<SCRIPT src="http://ds.eyeblaster.com/BurstingScript/addineye.js">
+<script>
+	var strProtocol = ( "https:" == document.location.protocol ? "https://" : "http://" );
+	var strAddInEyeSrc = "ds.serving-sys.com/BurstingScript/addineye.js";
+	if(strProtocol == "https://")
+		strAddInEyeSrc = "secure-"+ strAddInEyeSrc;
+	strAddInEyeSrc = strProtocol + strAddInEyeSrc;
+	document.write("<scr"+"ipt src="+strAddInEyeSrc+"></scr"+"ipt>");
 </script>
 </BODY>
 </HTML>


### PR DESCRIPTION
differentiating script source by protocol

This differs from the official version the mean of setting strProtocol variable - is not rellying on the value but check the value agains known values.

cc @sboisvert 
