### PR TITLE
Explicitly select which adbusters to support

### DIFF
--- a/adbusters.php
+++ b/adbusters.php
@@ -80,7 +80,7 @@ function wpcom_vip_maybe_load_ad_busters() {
 	$ad_busters = wpcom_vip_get_ad_busters_array();
 
 	// To only support a specific ad network, use this filter and return an array containing the values of $ad_busters to load
-	$whitelist_ads = (array) apply_filters( 'wpcom_vip_maybe_load_ad_busters_whitelist', $ad_busters );
+	$whitelist_ads = (array) apply_filters( 'wpcom_vip_ad_busters_whitelist', $ad_busters );
 	$ad_busters = array_filter( $ad_busters, function( $ad_buster_path ) use ( $whitelist_ads ){
 		return in_array( $ad_buster_path, $whitelist_ads );
 	} );

--- a/adbusters.php
+++ b/adbusters.php
@@ -79,10 +79,20 @@ function wpcom_vip_maybe_load_ad_busters() {
 
 	$ad_busters = wpcom_vip_get_ad_busters_array();
 
+	// To only support a specific ad network, use this filter and return an array containing the values of $ad_busters to load
+	$whitelist_ads = (array) apply_filters( 'wpcom_vip_maybe_load_ad_busters_whitelist', $ad_busters );
+	$ad_busters = array_filter( $ad_busters, function( $ad_buster_path ) use ( $whitelist_ads ){
+		return in_array( $ad_buster_path, $whitelist_ads );
+	} );
+
 	// To ignore an ad network, use this filter and return an array containing the values of $ad_busters to not load
 	$block_ads  = apply_filters( 'wpcom_vip_maybe_load_ad_busters', array() );
 	$ad_busters = array_diff( $ad_busters, $block_ads );
 	$ad_paths   = $ad_busters;
+
+	// nothing to do if there are no paths after whitelisting and blocking
+	if ( empty( $ad_paths ) )
+		return;
 
 	// If your ads need to be served from example.com/some/subfolder/*, pass "some/subfolder" to this filter
 	$path = explode( '/', apply_filters( 'wpcom_vip_ad_busters_custom_path', '' ) );

--- a/adbusters.php
+++ b/adbusters.php
@@ -43,7 +43,7 @@ function wpcom_vip_get_ad_busters_array() {
 		'doubleclick/fif.html',              // Flite
 		'eyeblaster/addineyeV2.html',        // MediaMind - EyeBlaster
 		'eyewonder/interim.html',            // EyeWonder
-		'f3-iframeout/f3-iframeout.html',    // F Sharp 
+		'f3-iframeout/f3-iframeout.html',    // F Sharp
 		'flashtalking/ftlocal.html',         // Flashtalking
 		'flite/fif.html',                    // Flite
 		'gumgum/iframe_buster.html',         // gumgum


### PR DESCRIPTION
Introducing a new filter ‘wpcom_vip_maybe_load_ad_busters_whitelist’
that allows selection which adbusters to be served. See issue #2.