### PR TITLE
Remove unsupported F Sharp iframe buster

### DIFF
--- a/adbusters.php
+++ b/adbusters.php
@@ -3,7 +3,7 @@
 Plugin Name: Adbusters
 Plugin URI: https://github.com/Automattic/Adbusters
 Description: Iframe busters for popular ad networks.
-Version: 1.0.6
+Version: 1.0.7
 Requires at least: 3.7
 License: GPLv3
 Author: Paul Gibbs, Mohammad Jangda, Automattic
@@ -42,7 +42,6 @@ function wpcom_vip_get_ad_busters_array() {
 		'doubleclick/DARTIframe.html',        // Google - DoubleClick
 		'doubleclick/fif.html',               // Flite
 		'doubleclick/TLIframe.html',          // TripleLift
-		'f3-iframeout/f3-iframeout.html',     // F Sharp
 		'flite/fif.html',                     // Flite
 		'gumgum/iframe_buster.html',          // gumgum
 		'jpd/jpxdm.html',                     // Jetpack Digital

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: DJPaul, batmoo, automattic
 Tags: ads, iframe busters, ad network
 Requires at least: 3.7
 Tested up to: 4.9.4
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/templates/f3-iframeout/f3-iframeout.html
+++ b/templates/f3-iframeout/f3-iframeout.html
@@ -1,6 +1,0 @@
-<html>
-<head><title>F# IFrame Popout</title></head>
-<body style="padding:0; margin:0">
-<script src="http://s3-us-west-2.amazonaws.com/f3-iframeout/f3-iframeout.js"></script>
-</body>
-</html>


### PR DESCRIPTION
The F Sharp buster in `f3-iframeout.html` points to an S3 bucket that F Sharp does not own