### PR TITLE
Fix PHPUnit dependency alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
 		"php-parallel-lint/php-parallel-lint": "^1.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
+		"phpunit/phpunit": "^8.5.52 || ^9.6.33",
 		"squizlabs/php_codesniffer": "^3.5",
 		"wp-coding-standards/wpcs": "^2.3.0",
 		"yoast/phpunit-polyfills": "^0.2.0"


### PR DESCRIPTION
## Summary
- narrow the PHPUnit dev dependency range to patched 8.5.x and 9.6.x releases

## Testing
- `composer validate --no-check-publish`
- `composer update --dry-run --no-interaction --no-scripts --no-plugins`
- `git diff --check`